### PR TITLE
Make profile info types consistent

### DIFF
--- a/content/docs/info-types.md
+++ b/content/docs/info-types.md
@@ -13,10 +13,12 @@ Your type schema needs to have `url`, `name`, `description`, `version`, and `con
 #### Example
 ```json
 {
-  "url": "https://tent.io/types/info/relationship-status",
+  "type": {
+    "url": "https://tent.io/types/info/relationship-status",
+    "version": "0.1.0"
+  },
   "name": "Relationship Status",
   "description": "Publish your relationship status",
-  "version": "0.1.0",
   "content": {
     "status": "single",
     "interested_in": ["women"],
@@ -37,10 +39,12 @@ Every profile JSON file must have this
 
 ```json
 {
-  "url": "https://tent.io/types/info/tent",
+  "type": {
+    "url": "https://tent.io/types/info/tent",
+    "version": "0.1.0"
+  },
   "name": "Tent",
   "description": "Core of self.json, must be included to be Tent compatible",
-  "version": "0.1.0",
   "content": {
     "licences": [
       {
@@ -70,10 +74,12 @@ Basic personal information.
 
 ```json
 {
-  "url": "https://tent.io/types/info/profile",
+  "type": {
+    "url": "https://tent.io/types/info/profile",
+    "version": "0.1.0"
+  },
   "name": "Profile",
   "description": "Basic personal information",
-  "version": "0.1.0",
   "content": {
     "display_name": "jdoe",
     "full_name": "Dr. John Blake Doe",

--- a/content/docs/profile.md
+++ b/content/docs/profile.md
@@ -18,16 +18,20 @@ A very basic profile might look like this:
       "url": "https://tent.io",
       "version": "0.1.0"
     },
-    "licenses": [
-      {
-        "url": "https://tent.io/types/licenses/creative-commons",
-        "version": "3.0.0"
-      }
-    ],
-    "entity": "johnsmith.io",
-    "servers": [
-      "https://tent.johnsmith.io"
-    ]
+    "name": "tent.io specification",
+    "description": "Specification for tent.io servers.",
+    "content": {
+      "licenses": [
+        {
+          "url": "https://tent.io/types/licenses/creative-commons",
+          "version": "3.0.0"
+        }
+      ],
+      "entity": "johnsmith.io",
+      "servers": [
+        "https://tent.johnsmith.io"
+      ]
+    }
   }
 ]
 ```
@@ -45,32 +49,36 @@ You could add support for another Tent version like this:
       "url": "https://tent.io",
       "version": "0.1.0"
     },
-    "licenses": [
-      {
-        "url": "https://tent.io/types/licenses/creative-commons",
-        "version": "3.0.0"
-      }
-    ],
-    "entity": "johnsmith.io",
-    "servers": [
-      "https://tent.johnsmith.io"
-    ]
+    "content": {
+      "licenses": [
+        {
+          "url": "https://tent.io/types/licenses/creative-commons",
+          "version": "3.0.0"
+        }
+      ],
+      "entity": "johnsmith.io",
+      "servers": [
+        "https://tent.johnsmith.io"
+      ]
+    }
   },
   {
     "type": {
       "url": "https://tent.io",
       "version": "0.2.0"
     },
-    "licenses": [
-      {
-        "url": "https://tent.io/types/licenses/creative-commons",
-        "version": "3.0.0"
-      }
-    ],
-    "entity": "johnsmith.io",
-    "servers": [
-      "https://tent.johnsmith.io"
-    ]
+    "content": {
+      "licenses": [
+        {
+          "url": "https://tent.io/types/licenses/creative-commons",
+          "version": "3.0.0"
+        }
+      ],
+      "entity": "johnsmith.io",
+      "servers": [
+        "https://tent.johnsmith.io"
+      ]
+    }
   }
 ]
 ```
@@ -84,24 +92,28 @@ You could add your basic information:
       "url": "https://tent.io",
       "version": "0.1.0"
     },
-    "licenses": [
-      {
-        "url": "https://tent.io/types/licenses/creative-commons",
-        "version": "3.0.0"
-      }
-    ],
-    "entity": "johnsmith.io",
-    "servers": [
-      "https://tent.johnsmith.io"
-    ]
+    "content": {
+      "licenses": [
+        {
+          "url": "https://tent.io/types/licenses/creative-commons",
+          "version": "3.0.0"
+        }
+      ],
+      "entity": "johnsmith.io",
+      "servers": [
+        "https://tent.johnsmith.io"
+      ]
+    }
   },
   {
     "type": {
       "url": "https://tent.io/types/info-types/basic-info",
       "version": "0.1.0"
     },
-    "name": "John Smith",
-    "age": 25
+    "content": {
+      "name": "John Smith",
+      "age": 25
+    }
   }
 ]
 ```


### PR DESCRIPTION
I'm attempting to make the profile info types more consistent so the array of profile types that come back from /profile look consistent and there are not different ways to do things depending on which spec profile type you're sending back.

In the old spec, the profile information that was coming back to specify which version of tent.io the server supported differed from the other profile information coming back which didn't make sense to me and was making things a little complicated when trying to implement the spec in .NET.
