### PR TITLE
Remove extraneous step from "Lifecycle of a post"

### DIFF
--- a/content/index.slim
+++ b/content/index.slim
@@ -24,7 +24,6 @@
   b Lifecycle of a post
   p
     ol
-      li Alice goes to a restaurant.
       li Alice writes a short message on TentStatus
       li TentStatus sends the message to Alice's server
       li Alice's server sends the status to two friends (Bob's and Carol's) servers.


### PR DESCRIPTION
The first step of "Lifecycle of a post" is unnecessary. It plays no part in the explanation. Furthermore, the use of the word "restaurant" may cause confusion about the "servers" in subsequent steps.
