### PR TITLE
Update docs: Status posts are 256 chars long now

### DIFF
--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -57,7 +57,7 @@ Users set permissions on each post that determine which other users can access t
 
 Post types describe the format and content of each post. Tent posts can be used for almost anything, and developers can create new post types for different kinds of media, interactions, or applications. 
 
-This documentation describes four basic post types: `status`, short messages of 140 characters or less, `essay`, longer form writing, `photo`, pictures, and `album`, a collection of `photo` posts. 
+This documentation describes four basic post types: `status`, short messages of 256 characters or less, `essay`, longer form writing, `photo`, pictures, and `album`, a collection of `photo` posts. 
 
 ### Profiles
 


### PR DESCRIPTION
On the Protocol Introduction page, change Status post length from 140 to 256 characters.

It's already 256 on the Post Types page.
