### PR TITLE
Added a minor note about where to send API requests

### DIFF
--- a/content/docs/app-server.md
+++ b/content/docs/app-server.md
@@ -4,7 +4,7 @@ title: Server API for Apps
 
 ## Server API for Apps
 
-Users interact with their own server primarily through apps. They can set permissions for different apps to limit the scope of access and control over the server.
+Users interact with their own server primarily through apps. They can set permissions for different apps to limit the scope of access and control over the server. All requests should be sent to the tent api root, as provided during the first step of authentication via HEAD request to the entity URI.
 
 ### GET /profile
 


### PR DESCRIPTION
This should make it easier for people who don't read the protocol documentation page to still be able to understand where to query the API.
