### PR TITLE
Document "mentioned_entity" parameter to "GET /posts"

### DIFF
--- a/content/docs/app-server.md
+++ b/content/docs/app-server.md
@@ -112,7 +112,7 @@ GET parameters can be used to filter and paginate the returned posts.
 | `since_time` | Posts with `published_at` greater than the specified unix epoch. |
 | `before_time` | Posts with `published_at` less than the specified unix epoch. |
 | `entity` | Posts published by the specified entity. |
-| `mentioned_entity` | Posts that mention that specified entity. |
+| `mentioned_entity` | Posts that mention the specified entity. |
 | `post_types` | Posts that match specific comma-separated type URIs. |
 | `limit` | The number of posts to return (defaults to the maximum of 200). |
 


### PR DESCRIPTION
This adds documentation for the `mentioned_entity` parameter, discussed in issue #99.
