### PR TITLE
Add to discovery docs (Link URLs can be absolute; entity URL can change)

### DIFF
--- a/content/docs/server-protocol.md
+++ b/content/docs/server-protocol.md
@@ -15,13 +15,13 @@ Servers should always be online and be accessible over HTTPS.
 
 Users and applications discover Tent servers in one of two ways: HTTP `Link` Headers and HTML `link` tags. Users can provide multiple links to access their Tent server. Multiple links are usually provided in case a particular address becomes unavailable. When multiple links are listed, they should be listed in order of preference from most preferred to least preferred, and contact attempted in the same order.
 
+These links can be either absolute or relative URLs.
 
 #### HTTP `Link` Header
 
 The HTTP header allows discovery of Tent servers by performing a HEAD request
 instead of retrieving the entire page and parsing for the `link` tag. It should be
 added to all responses associated with the Tent entity. Other pages associated with the user may also serve the same header.
-
 
 ```text
 Link: <https://tent.titanous.com/profile>; rel="https://tent.io/rels/profile"
@@ -52,8 +52,9 @@ To get a list of canonical API roots, do this:
 
 * Perform a `GET` request on the profile address using an `Accept: application/vnd.tent.v0+json` header, as specified on the [Server API for Apps](http://tent.io/docs/app-server) page.
 * You will get back the profile as a JSON object. The list of API roots will be in `json["https://tent.io/types/info/core/v0.1.0"]["servers"]`.
+* You should also get the entity URL from `json["https://tent.io/types/info/core/v0.1.0"]["entity"]`.  This is the canonical entity URL and it might be different than the entity URL you started with before discovery.
 
-There may be more than one API root in this list.  Like multiple `Link` headers, multiple server URLs should be
+There may be more than one API root in the `servers` list.  Like multiple `Link` headers, multiple server URLs should be
 treated as backups/fallbacks and tried in the order listed. If a post is successfully sent to one of the listed
 servers, then the entity is considered to have received it.
 


### PR DESCRIPTION
Rebased and trying again.

@titanous said on the mailing list that Link URLs can be relative:
http://librelist.com/browser//tent.dev/2012/10/4/should-the-profile-link-always-be-absolute-or-is-relative-ok/#037cf4147ab37edefcf3fbca29d8a0e6

---

This also adds a note that the entity URL you start with before discovery might be different than the entity URL you end up with after discovery.  Here's a case where that would happen:

Say I have an account at `https://me.tent.is`.  I want people to be able to find it from my personal blog at `http://myblog.com`, so I add a `<link>` header there pointing to `https://me.tent.is/tent/profile`.

Now someone does discovery starting with
`entityURL = "http://myblog.com"`

During discovery that profile URL will be fetched to get the API root URL and entity URL.  The results will be:

```
apiRootURLs = ["https://me.tent.is/tent"]
entityURL = "https://me.tent.is"
```

This use case is like a redirect: if someone tries to follow me at `http://myblog.com` they will end up following the more canonical entity `https://me.tent.is`.

(Or if tent.is returned my blog link as my entity name, I would be able to use `http://myblog.com` as my entity name everywhere even though my tent server was actually tent.is)
