### PR TITLE
updated server-protocol.md server discovery link

### DIFF
--- a/content/docs/server-protocol.md
+++ b/content/docs/server-protocol.md
@@ -31,7 +31,7 @@ or
 
 ```text
 Link: <https://tent.titanous.com/profile>; rel="https://tent.io/rels/profile",
-      <https://titanous.tent.is/profile>; rel="https://tent.io/rels/profile",
+      <https://titanous.tent.is/tent/profile>; rel="https://tent.io/rels/profile",
       <https://tent.jonathan.cloudmir.com/profile>; rel="https://tent.io/rels/profile"
 ```
 


### PR DESCRIPTION
Change is made because: It seems that /profile API for tent.is is /tent/profile. According to the protocol, the Link tag in html header for server discover should be point to /profile API.
