### PR TITLE
Add "since_id_entity" and "before_id_entity" to docs for GET /posts

### DIFF
--- a/content/docs/app-server.md
+++ b/content/docs/app-server.md
@@ -109,6 +109,8 @@ GET parameters can be used to filter and paginate the returned posts.
 | ---- | ----------- |
 | `since_id` | Posts made since a specific post identifier. |
 | `before_id` | Posts made before a specific post identifier. |
+| `since_id_entity` | The entity which made the post that has the id given in `since_id`.  This can be omitted if the post's owner is the one receiving the `GET /posts` request.  |
+| `before_id_entity` | The entity which made the post that has the id given in `before_id`.  This can be omitted if the post's owner is the one receiving the `GET /posts` request.  |
 | `since_time` | Posts with `published_at` greater than the specified unix epoch. |
 | `before_time` | Posts with `published_at` less than the specified unix epoch. |
 | `entity` | Posts published by the specified entity. |


### PR DESCRIPTION
These parameters of `GET /posts` were missing from the docs.

@titanous mentioned them here: https://github.com/tent/tentd/issues/18
