### PR TITLE
Meta profile details

### DIFF
--- a/content/docs/post-types.md
+++ b/content/docs/post-types.md
@@ -27,6 +27,9 @@ All entities notified of this change must rewrite their posts with the updated
 to the post `entity` as well as entities used in mentions, version parents,
 groups and permissions.
 
+The post also includes some "profile" details. These details are optionally made
+available to apps when they request posts.
+
 Modified meta posts are sent to all relationships and apps regardless of
 subscriptions.
 
@@ -215,11 +218,3 @@ A favorite references another post.
 The post may include a mention of the original post. The type fragment must be set to the type of the original post.
 
 {post_favorite schema}
-
-### Basic Profile
-
-`https://tent.io/types/basic-profile/v0`
-
-The basic profile describes the entity that published it.
-
-{post_basic-profile schema}


### PR DESCRIPTION
The basic profile has been completely removed, and most of the fields moved to the meta post. An optional parameter set when requesting a single post or list of post data allows apps to receive an object containing these profile fields for each entity that published an included post, as well as mentioned entities.

**List Page**

``` json
{
  "pages": {},
  "posts": ["..."],
  "refs": ["..."],
  "profiles": {
    "https://jonathan.tent.is": {
      "name": "Jonathan Rudenberg",
      "location": "The Internet",
      "avatar_digest": "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
    }
  }
}
```

**Single Post**

``` json
{
  "post": {},
  "refs": ["..."],
  "profiles": {
    "https://jonathan.tent.is": {
      "name": "Jonathan Rudenberg",
      "location": "The Internet",
      "avatar_digest": "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
    }
  }
}
```

See also tent/tent-schemas#7.
