### PR TITLE
Slight fix to newlines in hawk examples.

### DIFF
--- a/source/docs/authentication.html.md
+++ b/source/docs/authentication.html.md
@@ -104,7 +104,6 @@ example.com
 
 1234
 
-
 ```
 
 **Example: response with hash, no app**
@@ -117,7 +116,6 @@ POST
 /resource?a=1&b=2
 example.com
 8000
-
 tREz+ddQOD9BUtIoQtq2W0u2qFlJrRbWpr0+y+Ux78Q=
 
 ```


### PR DESCRIPTION
(Not a Hawk guy but this looked right to me)
### For the example with app

Port is 8000.
hash and ext are blank.
app is 1234.
dlg is blank.
### For the example with a hash but no app

Port is 8000.
hash is tREz+ddQOD9BUtIoQtq2W0u2qFlJrRbWpr0+y+Ux78Q=
ext is blank.
app and dlg are omitted.
